### PR TITLE
Add connection options to client

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ require 'kubernetes'
 # Assumes you're running a local proxy or SSH tunnel.
 client = Kubernetes.new
 
+# Connect to server from within a pod:
+token = File.read('/var/run/secrets/kubernetes.io/serviceaccount/token')
+client = Kubernetes.new({
+  connection: {
+    host: 'https://kubernetes', 
+    headers: { Authorization: "Bearer #{token}"}, 
+    ssl_verify_peer: false }})
+
 # Lists all pods:
 client.get_pods
 

--- a/kubernetes.gemspec
+++ b/kubernetes.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Daniel Schierbeck"]
   spec.email         = ["dasch@zendesk.com"]
 
-  spec.summary       = %q{TODO: Write a short summary, because Rubygems requires one.}
-  spec.description   = %q{TODO: Write a longer description or delete this line.}
+  spec.summary       = %q{A basic K8s interface gem}
+  spec.description   = %q{A basic K8s interface gem}
   spec.homepage      = "TODO: Put your gem's website or public repo URL here."
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }

--- a/lib/kubernetes/connection.rb
+++ b/lib/kubernetes/connection.rb
@@ -6,8 +6,8 @@ module Kubernetes
 
     attr_reader :namespace
 
-    def initialize(host: KUBERNETES_HOST, namespace:)
-      @connection = Excon.new(host)
+    def initialize(host: KUBERNETES_HOST, namespace:, options: {})
+      @connection = Excon.new(host, options)
       @namespace = namespace
     end
 

--- a/lib/kubernetes/pod_status.rb
+++ b/lib/kubernetes/pod_status.rb
@@ -2,6 +2,8 @@ require 'time'
 
 module Kubernetes
   class PodStatus
+    attr_reader :phase, :reason, :message
+
     def initialize(data)
       @phase = data.fetch("phase")
       @message = data.fetch("message", nil)


### PR DESCRIPTION
- Added connection options to client so that you can set the Excon connection attributes.
- Added ability for `watch_pods` to watch a specific pod and set the namespace otherwise it wouldn't see any pod events for a specific pod `name`.
- Added `delete_pod` function

Updated gemspec description/summary because Bundler wasn't letting me link to local path without them. :(
